### PR TITLE
WIP: OpenRAVE debian12 enable recording

### DIFF
--- a/openrave_python3/Dockerfile
+++ b/openrave_python3/Dockerfile
@@ -86,7 +86,7 @@ RUN git clone https://github.com/rdiankov/openrave.git && mkdir openrave/build &
     cd openrave/build && \
     git config --local user.email 'dockerfile@vagrant.example.com' && \
     git config --local user.name 'dockerfile' && \
-    git checkout origin/production && \
+    git checkout origin/1264-ffmpeg5-compat && \
     git cherry-pick cb96ec7318af7753e947a333dafe49bf6cacef01 && \
     git cherry-pick 53b90e081139a8d9c903d2e702322ba97a8bc494 && \
     git cherry-pick bb7e3d83f1bb6e93692f9557c205a7307c4beeb6 && \

--- a/openrave_python3/Dockerfile
+++ b/openrave_python3/Dockerfile
@@ -87,7 +87,7 @@ RUN git clone https://github.com/rdiankov/openrave.git && mkdir openrave/build &
     if grep '^Ubuntu J' /etc/issue >/dev/null || grep '^Ubuntu 22' /etc/issue >/dev/null || grep '^Debian GNU/Linux 12' /etc/issue >/dev/null || grep '^Debian GNU/Linux bookworm' /etc/issue >/dev/null; then \
       FLAG_CMAKE_CXX_STANDARD="-DCMAKE_CXX_STANDARD=17"; \
     fi && \
-    VIRTUAL_ENV=/root/openrave cmake .. -GNinja -DUSE_PYBIND11_PYTHON_BINDINGS=ON -DOPT_PYTHON=OFF -DOPT_BULLET=OFF -DPython3_FIND_VIRTUALENV=STANDARD ${FLAG_CMAKE_CXX_STANDARD} `&& \
+    VIRTUAL_ENV=/root/openrave cmake .. -GNinja -DUSE_PYBIND11_PYTHON_BINDINGS=ON -DOPT_PYTHON=OFF -DOPT_BULLET=OFF -DPython3_FIND_VIRTUALENV=STANDARD ${FLAG_CMAKE_CXX_STANDARD} && \
     ninja -j4 && ninja install && \
     cd ../.. && rm -rf openrave
 

--- a/openrave_python3/Dockerfile
+++ b/openrave_python3/Dockerfile
@@ -87,7 +87,7 @@ RUN git clone https://github.com/rdiankov/openrave.git && mkdir openrave/build &
     if grep '^Ubuntu J' /etc/issue >/dev/null || grep '^Ubuntu 22' /etc/issue >/dev/null || grep '^Debian GNU/Linux 12' /etc/issue >/dev/null || grep '^Debian GNU/Linux bookworm' /etc/issue >/dev/null; then \
       FLAG_CMAKE_CXX_STANDARD="-DCMAKE_CXX_STANDARD=17"; \
     fi && \
-    VIRTUAL_ENV=/root/openrave cmake .. -GNinja -DUSE_PYBIND11_PYTHON_BINDINGS=ON -DOPT_PYTHON=OFF -DPython3_FIND_VIRTUALENV=STANDARD ${FLAG_CMAKE_CXX_STANDARD} -DOPT_VIDEORECORDING=OFF && \
+    VIRTUAL_ENV=/root/openrave cmake .. -GNinja -DUSE_PYBIND11_PYTHON_BINDINGS=ON -DOPT_PYTHON=OFF -DPython3_FIND_VIRTUALENV=STANDARD ${FLAG_CMAKE_CXX_STANDARD} && \
     ninja -j4 && ninja install && \
     cd ../.. && rm -rf openrave
 


### PR DESCRIPTION
cc @felixvd @hemangandhi

original issue: https://github.com/rdiankov/openrave/issues/1264

running `sh openrave_bookworm.sh` causes this

```
246.1 /openrave/plugins/logging/viewerrecorder.cpp: In constructor 'VideoGlobalState::VideoGlobalState()':
246.1 /openrave/plugins/logging/viewerrecorder.cpp:74:9: error: 'av_register_all' was not declared in this scope
246.1    74 |         av_register_all();
246.1       |         ^~~~~~~~~~~~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp: In member function 'void ViewerRecorder::_ResetLibrary()':
246.1 /openrave/plugins/logging/viewerrecorder.cpp:656:36: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   656 |             avcodec_close(_stream->codec);
246.1       |                                    ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp: In member function 'bool ViewerRecorder::_GetCodecsCommand(std::ostream&, std::istream&)':
246.1 /openrave/plugins/logging/viewerrecorder.cpp:686:31: error: 'av_oformat_next' was not declared in this scope
246.1   686 |         AVOutputFormat *fmt = av_oformat_next(NULL); //first_oformat;
246.1       |                               ^~~~~~~~~~~~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:705:24: error: 'AVOutputFormat' {aka 'struct AVOutputFormat'} has no member named 'next'
246.1   705 |             fmt = fmt->next;
246.1       |                        ^~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp: In member function 'void ViewerRecorder::_StartVideo(const std::string&, double, int, int, int, int)':
246.1 /openrave/plugins/logging/viewerrecorder.cpp:727:31: error: 'av_oformat_next' was not declared in this scope
246.1   727 |         AVOutputFormat *fmt = av_oformat_next(NULL); //first_oformat;
246.1       |                               ^~~~~~~~~~~~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:741:28: error: 'AVOutputFormat' {aka 'struct AVOutputFormat'} has no member named 'next'
246.1   741 |                 fmt = fmt->next;
246.1       |                            ^~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:751:27: error: 'AVFormatContext' {aka 'struct AVFormatContext'} has no member named 'filename'
246.1   751 |         snprintf(_output->filename, sizeof(_output->filename), "%s", filename.c_str());
246.1       |                           ^~~~~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:751:53: error: 'AVFormatContext' {aka 'struct AVFormatContext'} has no member named 'filename'
246.1   751 |         snprintf(_output->filename, sizeof(_output->filename), "%s", filename.c_str());
246.1       |                                                     ^~~~~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:753:37: error: invalid conversion from 'const AVCodec*' to 'AVCodec*' [-fpermissive]
246.1   753 |         codec = avcodec_find_encoder(video_codec);
246.1       |                 ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
246.1       |                                     |
246.1       |                                     const AVCodec*
246.1 /openrave/plugins/logging/viewerrecorder.cpp:763:30: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   763 |         codec_ctx = _stream->codec;
246.1       |                              ^~~~~
246.1 In file included from /openrave/include/openrave/openrave.h:110,
246.1                  from /openrave/plugins/logging/plugindefs.h:20,
246.1                  from /openrave/plugins/logging/viewerrecorder.cpp:17:
246.1 /openrave/plugins/logging/viewerrecorder.cpp:797:94: error: 'AVFormatContext' {aka 'struct AVFormatContext'} has no member named 'filename'
246.1   797 |         RAVELOG_DEBUG(str(boost::format("opening %s, w:%d h:%dx fps:%f, codec: %s")%_output->filename%width%height%frameRate%codec->name));
246.1       |                                                                                              ^~~~~~~~
246.1 /openrave/include/openrave/logging.h:322:201: note: in definition of macro 'RAVELOG_LOGGER_LEVELA'
246.1   322 | #define RAVELOG_LOGGER_LEVELA(logger, LEVEL, level, ...) do { if (int(OpenRAVE::RaveGetDebugLevel()&OpenRAVE::Level_OutputMask)>=int(level)) { OpenRAVE::RavePrintfA ## LEVEL(logger, LOG4CXX_LOCATION, __VA_ARGS__); } } while (0)
246.1       |                                                                                                                                                                                                         ^~~~~~~~~~~
246.1 /openrave/include/openrave/logging.h:511:29: note: in expansion of macro 'RAVELOG_LEVELA'
246.1   511 | #define RAVELOG_DEBUGA(...) RAVELOG_LEVELA(_DEBUGLEVEL,OpenRAVE::Level_Debug,__VA_ARGS__)
246.1       |                             ^~~~~~~~~~~~~~
246.1 /openrave/include/openrave/logging.h:512:23: note: in expansion of macro 'RAVELOG_DEBUGA'
246.1   512 | #define RAVELOG_DEBUG RAVELOG_DEBUGA
246.1       |                       ^~~~~~~~~~~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:797:9: note: in expansion of macro 'RAVELOG_DEBUG'
246.1   797 |         RAVELOG_DEBUG(str(boost::format("opening %s, w:%d h:%dx fps:%f, codec: %s")%_output->filename%width%height%frameRate%codec->name));
246.1       |         ^~~~~~~~~~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:797:23: error: 'str' was not declared in this scope
246.1   797 |         RAVELOG_DEBUG(str(boost::format("opening %s, w:%d h:%dx fps:%f, codec: %s")%_output->filename%width%height%frameRate%codec->name));
246.1       |                       ^~~
246.1 /openrave/include/openrave/logging.h:322:201: note: in definition of macro 'RAVELOG_LOGGER_LEVELA'
246.1   322 | #define RAVELOG_LOGGER_LEVELA(logger, LEVEL, level, ...) do { if (int(OpenRAVE::RaveGetDebugLevel()&OpenRAVE::Level_OutputMask)>=int(level)) { OpenRAVE::RavePrintfA ## LEVEL(logger, LOG4CXX_LOCATION, __VA_ARGS__); } } while (0)
246.1       |                                                                                                                                                                                                         ^~~~~~~~~~~
246.1 /openrave/include/openrave/logging.h:511:29: note: in expansion of macro 'RAVELOG_LEVELA'
246.1   511 | #define RAVELOG_DEBUGA(...) RAVELOG_LEVELA(_DEBUGLEVEL,OpenRAVE::Level_Debug,__VA_ARGS__)
246.1       |                             ^~~~~~~~~~~~~~
246.1 /openrave/include/openrave/logging.h:512:23: note: in expansion of macro 'RAVELOG_DEBUGA'
246.1   512 | #define RAVELOG_DEBUG RAVELOG_DEBUGA
246.1       |                       ^~~~~~~~~~~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:797:9: note: in expansion of macro 'RAVELOG_DEBUG'
246.1   797 |         RAVELOG_DEBUG(str(boost::format("opening %s, w:%d h:%dx fps:%f, codec: %s")%_output->filename%width%height%frameRate%codec->name));
246.1       |         ^~~~~~~~~~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:797:23: note: suggested alternatives:
246.1   797 |         RAVELOG_DEBUG(str(boost::format("opening %s, w:%d h:%dx fps:%f, codec: %s")%_output->filename%width%height%frameRate%codec->name));
246.1       |                       ^~~
246.1 /openrave/include/openrave/logging.h:322:201: note: in definition of macro 'RAVELOG_LOGGER_LEVELA'
246.1   322 | #define RAVELOG_LOGGER_LEVELA(logger, LEVEL, level, ...) do { if (int(OpenRAVE::RaveGetDebugLevel()&OpenRAVE::Level_OutputMask)>=int(level)) { OpenRAVE::RavePrintfA ## LEVEL(logger, LOG4CXX_LOCATION, __VA_ARGS__); } } while (0)
246.1       |                                                                                                                                                                                                         ^~~~~~~~~~~
246.1 /openrave/include/openrave/logging.h:511:29: note: in expansion of macro 'RAVELOG_LEVELA'
246.1   511 | #define RAVELOG_DEBUGA(...) RAVELOG_LEVELA(_DEBUGLEVEL,OpenRAVE::Level_Debug,__VA_ARGS__)
246.1       |                             ^~~~~~~~~~~~~~
246.1 /openrave/include/openrave/logging.h:512:23: note: in expansion of macro 'RAVELOG_DEBUGA'
246.1   512 | #define RAVELOG_DEBUG RAVELOG_DEBUGA
246.1       |                       ^~~~~~~~~~~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:797:9: note: in expansion of macro 'RAVELOG_DEBUG'
246.1   797 |         RAVELOG_DEBUG(str(boost::format("opening %s, w:%d h:%dx fps:%f, codec: %s")%_output->filename%width%height%frameRate%codec->name));
246.1       |         ^~~~~~~~~~~~~
246.1 In file included from /usr/include/boost/format.hpp:53,
246.1                  from /openrave/include/openrave/openrave.h:82:
246.1 /usr/include/boost/format/free_funcs.hpp:22:38: note:   'boost::str'
246.1    22 |     std::basic_string<Ch, Tr, Alloc> str(const basic_format<Ch, Tr, Alloc>& f) {
246.1       |                                      ^~~
246.1 /usr/include/boost/format/free_funcs.hpp:22:38: note:   'boost::str'
246.1 /openrave/plugins/logging/viewerrecorder.cpp:839:25: error: 'avpicture_get_size' was not declared in this scope; did you mean '_picture_size'?
246.1   839 |         _picture_size = avpicture_get_size(AV_PIX_FMT_YUV420P, codec_ctx->width, codec_ctx->height);
246.1       |                         ^~~~~~~~~~~~~~~~~~
246.1       |                         _picture_size
246.1 /openrave/plugins/logging/viewerrecorder.cpp:847:25: error: 'AVPicture' was not declared in this scope; did you mean '_picture'?
246.1   847 |         avpicture_fill((AVPicture*)_yuv420p, (uint8_t*)_picture_buf, AV_PIX_FMT_YUV420P, codec_ctx->width, codec_ctx->height);
246.1       |                         ^~~~~~~~~
246.1       |                         _picture
246.1 /openrave/plugins/logging/viewerrecorder.cpp:847:35: error: expected primary-expression before ')' token
246.1   847 |         avpicture_fill((AVPicture*)_yuv420p, (uint8_t*)_picture_buf, AV_PIX_FMT_YUV420P, codec_ctx->width, codec_ctx->height);
246.1       |                                   ^
246.1 /openrave/plugins/logging/viewerrecorder.cpp:847:9: error: 'avpicture_fill' was not declared in this scope
246.1   847 |         avpicture_fill((AVPicture*)_yuv420p, (uint8_t*)_picture_buf, AV_PIX_FMT_YUV420P, codec_ctx->width, codec_ctx->height);
246.1       |         ^~~~~~~~~~~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp: In member function 'void ViewerRecorder::_AddFrame(void*)':
246.1 /openrave/plugins/logging/viewerrecorder.cpp:863:33: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   863 |         newdata.resize(_stream->codec->height*_stream->codec->width*3);
246.1       |                                 ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:863:56: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   863 |         newdata.resize(_stream->codec->height*_stream->codec->width*3);
246.1       |                                                        ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:864:50: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   864 |         char* penddata = (char*)pdata + _stream->codec->height*_stream->codec->width*3;
246.1       |                                                  ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:864:73: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   864 |         char* penddata = (char*)pdata + _stream->codec->height*_stream->codec->width*3;
246.1       |                                                                         ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:866:37: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   866 |         for(int i = 0; i < _stream->codec->height; ++i) {
246.1       |                                     ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:867:40: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   867 |             memcpy(&newdata[i*_stream->codec->width*3], (char*)penddata - (i+1)*_stream->codec->width*3, _stream->codec->width*3);
246.1       |                                        ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:867:90: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   867 |             memcpy(&newdata[i*_stream->codec->width*3], (char*)penddata - (i+1)*_stream->codec->width*3, _stream->codec->width*3);
246.1       |                                                                                          ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:867:115: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   867 |             memcpy(&newdata[i*_stream->codec->width*3], (char*)penddata - (i+1)*_stream->codec->width*3, _stream->codec->width*3);
246.1       |                                                                                                                   ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:871:42: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   871 |         _picture->linesize[0] = _stream->codec->width * 3;
246.1       |                                          ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:876:51: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   876 |         img_convert_ctx = sws_getContext(_stream->codec->width, _stream->codec->height, AV_PIX_FMT_BGR24, _stream->codec->width, _stream->codec->height, AV_PIX_FMT_YUV420P, SWS_BICUBIC /* flags */, NULL, NULL, NULL);
246.1       |                                                   ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:876:74: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   876 |         img_convert_ctx = sws_getContext(_stream->codec->width, _stream->codec->height, AV_PIX_FMT_BGR24, _stream->codec->width, _stream->codec->height, AV_PIX_FMT_YUV420P, SWS_BICUBIC /* flags */, NULL, NULL, NULL);
246.1       |                                                                          ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:876:116: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   876 |         img_convert_ctx = sws_getContext(_stream->codec->width, _stream->codec->height, AV_PIX_FMT_BGR24, _stream->codec->width, _stream->codec->height, AV_PIX_FMT_YUV420P, SWS_BICUBIC /* flags */, NULL, NULL, NULL);
246.1       |                                                                                                                    ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:876:139: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   876 |         img_convert_ctx = sws_getContext(_stream->codec->width, _stream->codec->height, AV_PIX_FMT_BGR24, _stream->codec->width, _stream->codec->height, AV_PIX_FMT_YUV420P, SWS_BICUBIC /* flags */, NULL, NULL, NULL);
246.1       |                                                                                                                                           ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:880:89: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   880 |         if (!sws_scale(img_convert_ctx, _picture->data, _picture->linesize, 0, _stream->codec->height, _yuv420p->data, _yuv420p->linesize)) {
246.1       |                                                                                         ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:896:23: warning: 'void av_init_packet(AVPacket*)' is deprecated [-Wdeprecated-declarations]
246.1   896 |         av_init_packet(&pkt);
246.1       |         ~~~~~~~~~~~~~~^~~~~~
246.1 In file included from /usr/include/x86_64-linux-gnu/libavformat/avformat.h:316,
246.1                  from /openrave/plugins/logging/viewerrecorder.cpp:60:
246.1 /usr/include/x86_64-linux-gnu/libavcodec/packet.h:512:6: note: declared here
246.1   512 | void av_init_packet(AVPacket *pkt);
246.1       |      ^~~~~~~~~~~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:897:50: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   897 |         int ret = avcodec_encode_video2(_stream->codec, &pkt, _yuv420p, &got_packet);
246.1       |                                                  ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:897:19: error: 'avcodec_encode_video2' was not declared in this scope; did you mean 'avcodec_encode_subtitle'?
246.1   897 |         int ret = avcodec_encode_video2(_stream->codec, &pkt, _yuv420p, &got_packet);
246.1       |                   ^~~~~~~~~~~~~~~~~~~~~
246.1       |                   avcodec_encode_subtitle
246.1 /openrave/plugins/logging/viewerrecorder.cpp:900:13: error: 'av_free_packet' was not declared in this scope; did you mean 'av_new_packet'?
246.1   900 |             av_free_packet(&pkt);
246.1       |             ^~~~~~~~~~~~~~
246.1       |             av_new_packet
246.1 /openrave/plugins/logging/viewerrecorder.cpp:907:26: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   907 |             if( _stream->codec->coded_frame) {
246.1       |                          ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:908:26: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   908 |                 _stream->codec->coded_frame->pts       = pkt.pts;
246.1       |                          ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:909:26: error: 'AVStream' {aka 'struct AVStream'} has no member named 'codec'
246.1   909 |                 _stream->codec->coded_frame->key_frame = !!(pkt.flags & AV_PKT_FLAG_KEY);
246.1       |                          ^~~~~
246.1 /openrave/plugins/logging/viewerrecorder.cpp:913:17: error: 'av_free_packet' was not declared in this scope; did you mean 'av_new_packet'?
246.1   913 |                 av_free_packet(&pkt);
246.1       |                 ^~~~~~~~~~~~~~
246.1       |                 av_new_packet
246.1 /openrave/plugins/logging/viewerrecorder.cpp:921:9: error: 'av_free_packet' was not declared in this scope; did you mean 'av_new_packet'?
246.1   921 |         av_free_packet(&pkt);
246.1       |         ^~~~~~~~~~~~~~
246.1       |         av_new_packet
246.1 /openrave/plugins/logging/viewerrecorder.cpp: In member function 'void ViewerRecorder::_StartVideo(const std::string&, double, int, int, int, int)':
246.1 /openrave/plugins/logging/viewerrecorder.cpp:810:30: warning: ignoring return value of 'int avformat_write_header(AVFormatContext*, AVDictionary**)' declared with attribute 'warn_unused_result' [-Wunused-result]
246.1   810 |         avformat_write_header(_output,NULL);
246.1       |         ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
246.7 [504/597] Building CXX object plugins/ikfastsolvers/CMakeFiles/ikfastsolvers.dir/ikfastmodule.cpp.o
250.2 [505/597] Building CXX object plugins/ikfastsolvers/CMakeFiles/ikfastsolvers.dir/ikfastsolver.cpp.o
250.3 [506/597] Building CXX object plugins/pqprave/CMakeFiles/pqprave.dir/pqprave.cpp.o
250.3 ninja: build stopped: subcommand failed.
```